### PR TITLE
0.1 Snapshot Release of MDF Connect Scala Bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
 *.class
 *.log
+.idea
+target
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+.history
+.cache
+.lib/
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 The University of Chicago
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ In order to use this library you will require a client id and secret. This
 can be obtained from [Globus](https://www.globus.org). You will then need to
 contact the MDF team to grant your account permission to publish via the API.
 
+We currently only support _confidential client_ authentication. This is
+appropriate for a back-end service, however future versions of this library
+should support the same OAuth flows exposed by the Python SDK.
+ 
 This library uses the Scala Play WS module to perform all of the REST calls.
 
 # How to Use

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Scala Bindings for Materials Data Facility API
+This library contains a service and associated case classes for interacting
+with MDF's Connect service. This service is used to submit datasets
+for ingesting into the [facility](https://materialsdatafacility.org).
+
+# Prerequisites
+In order to use this library you will require a client id and secret. This
+can be obtained from [Globus](https://www.globus.org). You will then need to
+contact the MDF team to grant your account permission to publish via the API.
+
+This library uses the Scala Play WS module to perform all of the REST calls.
+
+# How to Use
+The `MDFConnectPublishService` offers two methods:
+- `authenitcate` - Passes your client ID and secret to globus auth to receive
+an access token.
+- `submitConvertRequest` - Given an access token and a populated `ConvertRequest`
+this method will submit it to the service and return a simple result string.
+
+# Case Classes
+This library contains case classes to represent the JSON objects used by Globus
+auth and the MDF Connect service.  
+
+## DataCite
+This class encapsulates some of the basic data that can be represented by the
+MDF Connect [dc schema](https://github.com/materials-data-facility/data-schemas/blob/master/dc.json). The underlying schema can represent a rich network of collaborators and their
+affiliations. For now, this case class only represents the most basic cases and
+should eventually be extended to handle more.
+
+## ConvertRequest
+This class contains all of the information required to submit a dataset to
+MDF Connect for ingestion. In addition to a populated `DataCite` record, this
+records the URL from which MDFConnect can download the zipped dataset, and
+a boolean value which indicates if this is a test submission.

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "org.materialsdatafacility.mdfconnect"
 
 description := "Scala bindings for MDF Connect Service"
 
-version := "1.0-SNAPSHOT"
+version := "1.0"
 
 scalaVersion := "2.10.6"
 
@@ -22,7 +22,13 @@ libraryDependencies += "org.specs2" %% "specs2-mock" % "3.10.0" % Test
 
 libraryDependencies += "org.mockito" % "mockito-inline" % "2.7.22" % Test
 
-publishTo := Some("Sonatype Snapshots Nexus" at "https://oss.sonatype.org/content/repositories/snapshots")
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases"  at nexus + "content/repositories/releases")
+}
 
 credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,4 +18,6 @@ libraryDependencies += "org.specs2" %% "specs2-mock" % "3.10.0" % Test
 
 libraryDependencies += "org.mockito" % "mockito-inline" % "2.7.22" % Test
 
+//coverageExcludedPackages := "<empty>;Reverse.*;controllers.javascript.*;models\\.data\\..*;models.daos.*;modules.*;router.*; utils.auth.*;utils.Filters; views.*;services.adaptors.*"
+
 scalacOptions in Test ++= Seq("-Yrangepos")

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,21 @@
+
+import sbt.{TestFrameworks, Tests}
+
+name := "MDFConnect"
+
+version := "0.1"
+
+scalaVersion := "2.10.6"
+
+resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+
+// https://mvnrepository.com/artifact/com.typesafe.play/play
+libraryDependencies += "com.typesafe.play" %% "play" % "2.2.1"
+
+libraryDependencies += "org.specs2" %% "specs2-core" % "3.10.0" % Test
+
+libraryDependencies += "org.specs2" %% "specs2-mock" % "3.10.0" % Test
+
+libraryDependencies += "org.mockito" % "mockito-inline" % "2.7.22" % Test
+
+scalacOptions in Test ++= Seq("-Yrangepos")

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,13 @@
 
 import sbt.{TestFrameworks, Tests}
 
-name := "MDFConnect"
+name := "MDFConnectScala"
 
-version := "0.1"
+organization := "org.materialsdatafacility.mdfconnect"
+
+description := "Scala bindings for MDF Connect Service"
+
+version := "0.1-SNAPSHOT"
 
 scalaVersion := "2.10.6"
 
@@ -18,6 +22,21 @@ libraryDependencies += "org.specs2" %% "specs2-mock" % "3.10.0" % Test
 
 libraryDependencies += "org.mockito" % "mockito-inline" % "2.7.22" % Test
 
-//coverageExcludedPackages := "<empty>;Reverse.*;controllers.javascript.*;models\\.data\\..*;models.daos.*;modules.*;router.*; utils.auth.*;utils.Filters; views.*;services.adaptors.*"
+publishTo := Some("Sonatype Snapshots Nexus" at "https://oss.sonatype.org/content/repositories/snapshots")
+
+credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
+
+pomIncludeRepository := { _ => false }
+
+licenses := Seq("Apache" -> url("https://opensource.org/licenses/Apache-2.0"))
+
+homepage := Some(url("https://materialsdatafacility.org"))
+
+scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/materials-data-facility/MDFConnectScala"),
+    "scm:git@github.com:materials-data-facility/MDFConnectScala.git"
+  )
+)
 
 scalacOptions in Test ++= Seq("-Yrangepos")

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "org.materialsdatafacility.mdfconnect"
 
 description := "Scala bindings for MDF Connect Service"
 
-version := "0.1-SNAPSHOT"
+version := "1.0-SNAPSHOT"
 
 scalaVersion := "2.10.6"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,4 @@
+
+resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")

--- a/src/main/scala/org/materialsdatafacility/connect/models/AccessToken.scala
+++ b/src/main/scala/org/materialsdatafacility/connect/models/AccessToken.scala
@@ -2,8 +2,15 @@ package org.materialsdatafacility.connect.models
 
 import play.api.libs.json._
 
+/**
+  * Token go access a specific scope obtained from Globus Auth
+  * @param accessToken Token to be used when submitting operations to MDF Connect
+  * @param scope
+  * @param expiresIn
+  * @param resourceServer
+  * @param tokenType
+  */
 case class AccessToken (accessToken: String, scope:String, expiresIn:Int, resourceServer:String, tokenType:String)
-
 
 object AccessToken{
   implicit val accessTokenReads = new Reads[AccessToken] {

--- a/src/main/scala/org/materialsdatafacility/connect/models/AccessToken.scala
+++ b/src/main/scala/org/materialsdatafacility/connect/models/AccessToken.scala
@@ -1,0 +1,20 @@
+package org.materialsdatafacility.connect.models
+
+import play.api.libs.json._
+
+case class AccessToken (accessToken: String, scope:String, expiresIn:Int, resourceServer:String, tokenType:String)
+
+
+object AccessToken{
+  implicit val accessTokenReads = new Reads[AccessToken] {
+    def reads(json: JsValue): JsResult[AccessToken] =
+      JsSuccess(AccessToken(
+        (json \ "access_token").as[String],
+        (json \ "scope").as[String],
+        (json \ "expires_in").asInstanceOf[JsNumber].value.toInt,
+        (json \ "resource_server").as[String],
+        (json \ "token_type").as[String]))
+  }
+
+
+  }

--- a/src/main/scala/org/materialsdatafacility/connect/models/ConvertRequest.scala
+++ b/src/main/scala/org/materialsdatafacility/connect/models/ConvertRequest.scala
@@ -1,4 +1,20 @@
 package org.materialsdatafacility.connect.models
 
+import play.api.http.Writeable
+import play.api.libs.json._
+import play.api.mvc.Codec
+
 case class ConvertRequest(dataCite: DataCite, data: Seq[String], test: Option[Boolean])
+
+object ConvertRequest {
+  implicit val convertRequestWrites = new Writes[ConvertRequest] {
+    def writes(request: ConvertRequest): JsObject = {
+      Json.obj(
+        "dc" -> request.dataCite,
+        "data"->request.data,
+        "test"-> JsBoolean(request.test.getOrElse(true))
+      )
+    }
+  }
+}
 

--- a/src/main/scala/org/materialsdatafacility/connect/models/ConvertRequest.scala
+++ b/src/main/scala/org/materialsdatafacility/connect/models/ConvertRequest.scala
@@ -1,9 +1,13 @@
 package org.materialsdatafacility.connect.models
 
-import play.api.http.Writeable
 import play.api.libs.json._
-import play.api.mvc.Codec
 
+/**
+  * Case class to represent a single request to injest data by MDF Connect
+  * @param dataCite Data citation for the dataset
+  * @param data List of URLs where MDF Connect can download data
+  * @param test Is this a test run, or the real thing?
+  */
 case class ConvertRequest(dataCite: DataCite, data: Seq[String], test: Option[Boolean])
 
 object ConvertRequest {

--- a/src/main/scala/org/materialsdatafacility/connect/models/ConvertRequest.scala
+++ b/src/main/scala/org/materialsdatafacility/connect/models/ConvertRequest.scala
@@ -1,0 +1,4 @@
+package org.materialsdatafacility.connect.models
+
+case class ConvertRequest(dataCite: DataCite, data: Seq[String], test: Option[Boolean])
+

--- a/src/main/scala/org/materialsdatafacility/connect/models/DataCite.scala
+++ b/src/main/scala/org/materialsdatafacility/connect/models/DataCite.scala
@@ -1,0 +1,48 @@
+package org.materialsdatafacility.connect.models
+
+import org.joda.time.DateTime
+import play.api.libs.json._
+
+case class DataCite(title: Seq[String], authors: Seq[String],
+                    affiliations: Option[Seq[String]],
+                    publisher: Option[String],
+                    publication_year: Option[Int],
+                    resource_type: Option[String],
+                    description: Option[String],
+                    dataset_doi: Option[String],
+                    related_dois: Option[Seq[String]])
+
+  object DataCite {
+    implicit val dataCiteWrites = new Writes[DataCite]{
+      def writes(dc: DataCite):JsObject = {
+
+        val creators = dc.authors map{ creator =>
+          val (familyName, given) = extractNameParts(creator)
+          val creatorName = if (familyName.isEmpty) given else (s"$familyName, $given")
+          Json.obj(
+            "creatorName" -> creatorName,
+            "familyName" -> familyName,
+            "givenName" -> given
+          )
+        }
+
+        val (familyName, given) = extractNameParts(dc.authors.head)
+
+        val defaultPublicationYear = new DateTime().year().get()
+        Json.obj(
+          "titles" -> dc.title,
+          "creators" -> JsArray(creators),
+          "publisher" -> JsString(dc.publisher.getOrElse("Materials Data Facility")),
+          "publicationYear" -> JsString(dc.publication_year.getOrElse(defaultPublicationYear).toString)
+        )
+      }
+    }
+
+    private def extractNameParts(nameStr: String): (String, String) = {
+      if(nameStr.contains(",")) nameStr.split(",").toList match{ case last::first::Nil => (last.trim, first.trim) case _ => ("","")}
+      else if(nameStr.contains(";")) nameStr.split(";").toList match{ case last::first::Nil => (last.trim, first.trim) case _ => ("","")}
+      else if(nameStr.contains(" ")) nameStr.split(" ").toList match{ case first::last::Nil => (last.trim, first.trim) case _ => ("","")}
+      else ("", nameStr)
+    }
+  }
+

--- a/src/main/scala/org/materialsdatafacility/connect/models/DataCite.scala
+++ b/src/main/scala/org/materialsdatafacility/connect/models/DataCite.scala
@@ -3,6 +3,18 @@ package org.materialsdatafacility.connect.models
 import org.joda.time.DateTime
 import play.api.libs.json._
 
+/**
+  * A complete citation for a data submission
+  * @param title List of titles
+  * @param authors List of authors
+  * @param affiliations Affiliations for the authors - not currently used -
+  * @param publisher Name of the data publisher. Defaults to Materials Data Facility
+  * @param publication_year Defaults to the current year
+  * @param resource_type
+  * @param description Full text description
+  * @param dataset_doi DOI assigned to this dataset
+  * @param related_dois List of related DOIs
+  */
 case class DataCite(title: Seq[String], authors: Seq[String],
                     affiliations: Option[Seq[String]],
                     publisher: Option[String],
@@ -12,67 +24,78 @@ case class DataCite(title: Seq[String], authors: Seq[String],
                     dataset_doi: Option[String],
                     related_dois: Option[Seq[String]])
 
-  object DataCite {
-    implicit val dataCiteWrites = new Writes[DataCite]{
-      def writes(dc: DataCite):JsObject = {
+object DataCite {
+  implicit val dataCiteWrites = new Writes[DataCite] {
+    def writes(dc: DataCite): JsObject = {
 
-        val creators = dc.authors map{ creator =>
-          val (familyName, given) = extractNameParts(creator)
-          val creatorName = if (familyName.isEmpty) given else (s"$familyName, $given")
-          Json.obj(
-            "creatorName" -> creatorName,
-            "familyName" -> familyName,
-            "givenName" -> given
-          )
-        }
-
-        val titles = dc.title map{title =>
-          Json.obj("title"->title)
-        }
-
-        val (familyName, given) = extractNameParts(dc.authors.head)
-
-        val defaultPublicationYear = new DateTime().year().get()
-
-        // Basic object with the required fields
-        val basicObj = Json.obj(
-          "titles" -> JsArray(titles),
-          "creators" -> JsArray(creators),
-          "publisher" -> JsString(dc.publisher.getOrElse("Materials Data Facility")),
-          "publicationYear" -> JsString(dc.publication_year.getOrElse(defaultPublicationYear).toString)
+      val creators = dc.authors map { creator =>
+        val (familyName, given) = extractNameParts(creator)
+        val creatorName = if (familyName.isEmpty) given else (s"$familyName, $given")
+        Json.obj(
+          "creatorName" -> creatorName,
+          "familyName" -> familyName,
+          "givenName" -> given
         )
-
-        // Extend with optional properties
-        val objWithDescription = if(dc.description.isDefined) basicObj ++ Json.obj("descriptions"-> JsArray(Seq(Json.obj(
-          "description" -> JsString(dc.description.get),
-          "descriptionType"-> JsString("Other")
-        )))) else basicObj
-
-        val objWithResourceType = if(dc.resource_type.isDefined) objWithDescription ++ Json.obj(
-          "resourceType"-> Json.obj("resourceType"->dc.resource_type.get,
-            "resourceTypeGeneral"-> JsString("Dataset"))) else objWithDescription
-
-        val objWithDOI = if(dc.dataset_doi.isDefined) objWithResourceType ++ Json.obj(
-          "identifier"->Json.obj(
-            "identifier"->dc.dataset_doi.get,
-            "identifierType" -> "DOI")) else objWithResourceType
-
-        val relatedDOIEntry = if(dc.related_dois.isDefined) dc.related_dois.get map{doi => Json.obj(
-          "relatedIdentifier"->doi,
-          "relatedIdentifierType"->"DOI",
-          "relationType"-> "IsPartOf"
-        )} else List()
-
-        if(dc.related_dois.isDefined) objWithDOI ++ Json.obj(
-          "relatedIdentifiers"-> JsArray(relatedDOIEntry)) else objWithDOI
       }
-    }
 
-    private def extractNameParts(nameStr: String): (String, String) = {
-      if(nameStr.contains(",")) nameStr.split(",").toList match{ case last::first::Nil => (last.trim, first.trim) case _ => ("","")}
-      else if(nameStr.contains(";")) nameStr.split(";").toList match{ case last::first::Nil => (last.trim, first.trim) case _ => ("","")}
-      else if(nameStr.contains(" ")) nameStr.split(" ").toList match{ case first::last::Nil => (last.trim, first.trim) case _ => ("","")}
-      else ("", nameStr)
+      val titles = dc.title map { title =>
+        Json.obj("title" -> title)
+      }
+
+      val (familyName, given) = extractNameParts(dc.authors.head)
+
+      val defaultPublicationYear = new DateTime().year().get()
+
+      // Basic object with the required fields
+      val basicObj = Json.obj(
+        "titles" -> JsArray(titles),
+        "creators" -> JsArray(creators),
+        "publisher" -> JsString(dc.publisher.getOrElse("Materials Data Facility")),
+        "publicationYear" -> JsString(dc.publication_year.getOrElse(defaultPublicationYear).toString)
+      )
+
+      // Extend with optional properties
+      val objWithDescription = if (dc.description.isDefined) basicObj ++ Json.obj("descriptions" -> JsArray(Seq(Json.obj(
+        "description" -> JsString(dc.description.get),
+        "descriptionType" -> JsString("Other")
+      )))) else basicObj
+
+      val objWithResourceType = if (dc.resource_type.isDefined) objWithDescription ++ Json.obj(
+        "resourceType" -> Json.obj("resourceType" -> dc.resource_type.get,
+          "resourceTypeGeneral" -> JsString("Dataset"))) else objWithDescription
+
+      val objWithDOI = if (dc.dataset_doi.isDefined) objWithResourceType ++ Json.obj(
+        "identifier" -> Json.obj(
+          "identifier" -> dc.dataset_doi.get,
+          "identifierType" -> "DOI")) else objWithResourceType
+
+      val relatedDOIEntry = if (dc.related_dois.isDefined) dc.related_dois.get map { doi =>
+        Json.obj(
+          "relatedIdentifier" -> doi,
+          "relatedIdentifierType" -> "DOI",
+          "relationType" -> "IsPartOf"
+        )
+      } else List()
+
+      if (dc.related_dois.isDefined) objWithDOI ++ Json.obj(
+        "relatedIdentifiers" -> JsArray(relatedDOIEntry)) else objWithDOI
     }
   }
+
+  private def extractNameParts(nameStr: String): (String, String) = {
+    if (nameStr.contains(",")) nameStr.split(",").toList match {
+      case last :: first :: Nil => (last.trim, first.trim)
+      case _ => ("", "")
+    }
+    else if (nameStr.contains(";")) nameStr.split(";").toList match {
+      case last :: first :: Nil => (last.trim, first.trim)
+      case _ => ("", "")
+    }
+    else if (nameStr.contains(" ")) nameStr.split(" ").toList match {
+      case first :: last :: Nil => (last.trim, first.trim)
+      case _ => ("", "")
+    }
+    else ("", nameStr)
+  }
+}
 

--- a/src/main/scala/org/materialsdatafacility/connect/services/MDFPublishService.scala
+++ b/src/main/scala/org/materialsdatafacility/connect/services/MDFPublishService.scala
@@ -1,0 +1,39 @@
+package org.materialsdatafacility.connect.services
+
+import com.ning.http.client.Realm.AuthScheme
+import play.api.http.Status
+import play.api.libs.json.{JsArray, JsObject, JsString}
+import play.api.libs.ws.WS
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class MDFPublishService(ws: WS.type, clientID:String, secret:String) {
+
+  def authenticate(): Future[Try[String]] = {
+    ws.url("https://auth.globus.org/v2/oauth2/token")
+      .withAuth(clientID, secret, AuthScheme.BASIC)
+      .post(Map(
+        "grant_type" -> Seq("client_credentials"),
+        "scope" -> Seq("https://auth.globus.org/scopes/ab24b500-37a2-4bad-ab66-d8232c18e6e5/publish_api " +
+          "urn:globus:auth:scope:data.materialsdatafacility.org:all " +
+          "https://auth.globus.org/scopes/ab24b500-37a2-4bad-ab66-d8232c18e6e5/publish_api " +
+          "https://auth.globus.org/scopes/c17f27bb-f200-486a-b785-2a25e82af505/connect"))) map { result =>
+      result.status match{
+        case Status.OK => Success(s"Client ${clientID} Authenticated")
+        case Status.FORBIDDEN => Failure(new Exception("Can't authenticated client"))
+        case _ => Failure(new Exception(result.body))
+      }
+    }
+  }
+
+  def create_dc(title: String, authors:Seq[String]):JsObject = {
+    JsObject(Seq(
+      "title" -> JsString(title),
+      "authors" -> JsArray(authors map{a=>JsString(a)})
+    ))
+  }
+
+}
+

--- a/src/main/scala/org/materialsdatafacility/connect/services/MDFPublishService.scala
+++ b/src/main/scala/org/materialsdatafacility/connect/services/MDFPublishService.scala
@@ -1,9 +1,12 @@
 package org.materialsdatafacility.connect.services
 
 import com.ning.http.client.Realm.AuthScheme
-import play.api.http.Status
-import play.api.libs.json.{JsArray, JsObject, JsString}
+import org.materialsdatafacility.connect.models.{AccessToken, ConvertRequest}
+import play.api.http.{Status, Writeable}
+import play.api.libs.json._
 import play.api.libs.ws.WS
+import play.api.http._
+import play.api.mvc._
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
@@ -11,7 +14,17 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class MDFPublishService(ws: WS.type, clientID:String, secret:String) {
 
-  def authenticate(): Future[Try[String]] = {
+  implicit def writeable(implicit codec: Codec): Writeable[ConvertRequest] = {
+    // assuming RepositoryMetadata has a .toString
+    Writeable(data => codec.encode(data.toString))
+  }
+
+  implicit def contentType(implicit codec: Codec): ContentTypeOf[ConvertRequest] = {
+    // for text/plain
+    ContentTypeOf(Some(ContentTypes.JSON))
+  }
+
+  def authenticate(): Future[Try[AccessToken]] = {
     ws.url("https://auth.globus.org/v2/oauth2/token")
       .withAuth(clientID, secret, AuthScheme.BASIC)
       .post(Map(
@@ -21,19 +34,34 @@ class MDFPublishService(ws: WS.type, clientID:String, secret:String) {
           "https://auth.globus.org/scopes/ab24b500-37a2-4bad-ab66-d8232c18e6e5/publish_api " +
           "https://auth.globus.org/scopes/c17f27bb-f200-486a-b785-2a25e82af505/connect"))) map { result =>
       result.status match{
-        case Status.OK => Success(s"Client ${clientID} Authenticated")
+        case Status.OK => {
+          val tokens = (result.json\"other_tokens").as[Seq[AccessToken]]
+          tokens.find((p:AccessToken) => p.resourceServer.equals("mdf_dataset_submission")) match{
+            case Some(accessToken) => Success(accessToken)
+            case None => Failure(new Exception("Token for MDF Connect not found"))
+          }
+        }
         case Status.FORBIDDEN => Failure(new Exception("Can't authenticated client"))
         case _ => Failure(new Exception(result.body))
       }
     }
   }
 
-  def create_dc(title: String, authors:Seq[String]):JsObject = {
-    JsObject(Seq(
-      "title" -> JsString(title),
-      "authors" -> JsArray(authors map{a=>JsString(a)})
-    ))
-  }
+  def submitConvertRequest(convertRequest: ConvertRequest, accessToken: AccessToken): Future[Try[String]] = {
 
+    ws.url("https://34.193.81.207:5000/convert")
+      .withHeaders("Authorization"->accessToken.accessToken)
+      .post(convertRequest) map { result =>
+      result.status match{
+        case Status.OK => {
+          println(result.json)
+          Success(result.json.toString())
+        }
+        case _ =>{
+          Failure(new Exception("Convert request failed "+result.status+"-->"+result.body))
+        }
+      }
+      }
+  }
 }
 

--- a/src/main/scala/org/materialsdatafacility/connect/services/MDFPublishService.scala
+++ b/src/main/scala/org/materialsdatafacility/connect/services/MDFPublishService.scala
@@ -1,19 +1,42 @@
 package org.materialsdatafacility.connect.services
 
+import java.net.URL
+
 import com.ning.http.client.Realm.AuthScheme
 import org.materialsdatafacility.connect.models.{AccessToken, ConvertRequest}
-import play.api.http.{Status, Writeable}
-import play.api.libs.json._
+import play.api.http.{Status, Writeable, _}
 import play.api.libs.ws.WS
-import play.api.http._
 import play.api.mvc._
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
-import scala.concurrent.ExecutionContext.Implicits.global
 
-class MDFPublishService(ws: WS.type, clientID:String, secret:String) {
+/**
+  * Bindings for the MDF Connect REST API. This service is part of the Materials Data Facility project.
+  *
+  * @constructor Create a new connection to the service by passing in a Play WS webservice client, as
+  *              well as the client ID, and secret for the Globus account to be used with MDF Connect. Also
+  *              accepts the MDF Connect URL to use to be able to switch between production and test
+  * @param ws            Instance of the play webservice library
+  * @param clientID      Globus Client ID
+  * @param secret        Associated secret
+  * @param mdfConnectURL The URL to use to call MDF Connect operations
+  */
+class MDFPublishService(ws: WS.type, clientID: String, secret: String, mdfConnectURL: URL) {
 
+  private val globusAuthURL = "https://auth.globus.org/v2/oauth2/token"
+
+  /**
+    * List of scopes we will need in order to interact with MDF Connect
+    */
+  private val scopes = "https://auth.globus.org/scopes/ab24b500-37a2-4bad-ab66-d8232c18e6e5/publish_api " +
+    "urn:globus:auth:scope:data.materialsdatafacility.org:all " +
+    "https://auth.globus.org/scopes/ab24b500-37a2-4bad-ab66-d8232c18e6e5/publish_api " +
+    "https://auth.globus.org/scopes/c17f27bb-f200-486a-b785-2a25e82af505/connect"
+
+
+  // Some implicit methods to allow passing of json objects around
   implicit def writeable(implicit codec: Codec): Writeable[ConvertRequest] = {
     // assuming RepositoryMetadata has a .toString
     Writeable(data => codec.encode(data.toString))
@@ -24,19 +47,23 @@ class MDFPublishService(ws: WS.type, clientID:String, secret:String) {
     ContentTypeOf(Some(ContentTypes.JSON))
   }
 
+  /**
+    * Authenticate with Globus Auth to obtain a valid access token. This uses the client ID and secret
+    * associated with this instances
+    *
+    * @return Generated Access Token
+    */
   def authenticate(): Future[Try[AccessToken]] = {
-    ws.url("https://auth.globus.org/v2/oauth2/token")
+    ws.url(globusAuthURL)
       .withAuth(clientID, secret, AuthScheme.BASIC)
       .post(Map(
         "grant_type" -> Seq("client_credentials"),
-        "scope" -> Seq("https://auth.globus.org/scopes/ab24b500-37a2-4bad-ab66-d8232c18e6e5/publish_api " +
-          "urn:globus:auth:scope:data.materialsdatafacility.org:all " +
-          "https://auth.globus.org/scopes/ab24b500-37a2-4bad-ab66-d8232c18e6e5/publish_api " +
-          "https://auth.globus.org/scopes/c17f27bb-f200-486a-b785-2a25e82af505/connect"))) map { result =>
-      result.status match{
+        "scope" -> Seq(scopes))) map { result =>
+      result.status match {
         case Status.OK => {
-          val tokens = (result.json\"other_tokens").as[Seq[AccessToken]]
-          tokens.find((p:AccessToken) => p.resourceServer.equals("mdf_dataset_submission")) match{
+          // Find the MDF Dataset Submission scope and keep ahold of its token
+          val tokens = (result.json \ "other_tokens").as[Seq[AccessToken]]
+          tokens.find((p: AccessToken) => p.resourceServer.equals("mdf_dataset_submission")) match {
             case Some(accessToken) => Success(accessToken)
             case None => Failure(new Exception("Token for MDF Connect not found"))
           }
@@ -47,21 +74,32 @@ class MDFPublishService(ws: WS.type, clientID:String, secret:String) {
     }
   }
 
+  /**
+    * Submit a request to the MDF Connect service to start up a file injestion process
+    *
+    * @param convertRequest Completed ConvertRequest object
+    * @param accessToken    Access token obtained by calling authenticate()
+    * @return Result string or Failure
+    */
   def submitConvertRequest(convertRequest: ConvertRequest, accessToken: AccessToken): Future[Try[String]] = {
 
-    ws.url("https://34.193.81.207:5000/convert")
-      .withHeaders("Authorization"->accessToken.accessToken)
-      .post(convertRequest) map { result =>
-      result.status match{
-        case Status.OK => {
-          println(result.json)
+    /**
+      * @todo - this should work with an implicit writer instead of explicitly calling
+      *       the writes method.
+      */
+    val body = ConvertRequest.convertRequestWrites.writes(convertRequest)
+    ws.url(mdfConnectURL.toExternalForm)
+      .withHeaders("Authorization" -> accessToken.accessToken)
+      .post(body) map { result =>
+      result.status match {
+        case Status.ACCEPTED => {
           Success(result.json.toString())
         }
-        case _ =>{
-          Failure(new Exception("Convert request failed "+result.status+"-->"+result.body))
+        case _ => {
+          Failure(new Exception("Convert request failed " + result.status + "-->" + result.body))
         }
       }
-      }
+    }
   }
 }
 

--- a/src/test/scala/org/materialsdatafacility/connect/models/ConvertRequestSpec.scala
+++ b/src/test/scala/org/materialsdatafacility/connect/models/ConvertRequestSpec.scala
@@ -1,0 +1,64 @@
+package org.materialsdatafacility.connect.models
+
+import org.specs2.mutable._
+import play.api.libs.json._
+
+class ConvertRequestSpec extends Specification {
+  "Given a Convert Request" >> {
+    val dc = new DataCite(Seq("My title"), Seq("Bob Dobbo"), None, None, Some(1984), None, None, None, None)
+    val convertRequest = new ConvertRequest(dc, Seq("http://foo.com/bar", "http://bar.com/foo"), Some(false))
+
+    "When I write the JSON" >> {
+      val json = ConvertRequest.convertRequestWrites.writes(convertRequest)
+      "Then it should be formatted correctly" >>{
+        val result = Json.prettyPrint(json)
+        result must be equalTo(
+          """{
+            |  "dc" : {
+            |    "titles" : [ "My title" ],
+            |    "creators" : [ {
+            |      "creatorName" : "Dobbo, Bob",
+            |      "familyName" : "Dobbo",
+            |      "givenName" : "Bob"
+            |    } ],
+            |    "publisher" : "Materials Data Facility",
+            |    "publicationYear" : "1984"
+            |  },
+            |  "data" : [ "http://foo.com/bar", "http://bar.com/foo" ],
+            |  "test" : false
+            |}""".stripMargin
+        )
+      }
+    }
+  }
+
+  "Given a Convert Request that doesn't specify the test setting" >> {
+    val dc = new DataCite(Seq("My title"), Seq("Bob Dobbo"), None, None, Some(1984), None, None, None, None)
+    val convertRequest = new ConvertRequest(dc, Seq("http://foo.com/bar"), None)
+
+    "When I write the JSON" >> {
+      val json = ConvertRequest.convertRequestWrites.writes(convertRequest)
+      "Then it should default to true" >>{
+        val result = Json.prettyPrint(json)
+        result must be equalTo(
+          """{
+            |  "dc" : {
+            |    "titles" : [ "My title" ],
+            |    "creators" : [ {
+            |      "creatorName" : "Dobbo, Bob",
+            |      "familyName" : "Dobbo",
+            |      "givenName" : "Bob"
+            |    } ],
+            |    "publisher" : "Materials Data Facility",
+            |    "publicationYear" : "1984"
+            |  },
+            |  "data" : [ "http://foo.com/bar" ],
+            |  "test" : true
+            |}""".stripMargin
+          )
+      }
+    }
+  }
+
+
+}

--- a/src/test/scala/org/materialsdatafacility/connect/models/ConvertRequestSpec.scala
+++ b/src/test/scala/org/materialsdatafacility/connect/models/ConvertRequestSpec.scala
@@ -12,10 +12,12 @@ class ConvertRequestSpec extends Specification {
       val json = ConvertRequest.convertRequestWrites.writes(convertRequest)
       "Then it should be formatted correctly" >>{
         val result = Json.prettyPrint(json)
-        result must be equalTo(
+        result must be equalTo
           """{
             |  "dc" : {
-            |    "titles" : [ "My title" ],
+            |    "titles" : [ {
+            |      "title" : "My title"
+            |    } ],
             |    "creators" : [ {
             |      "creatorName" : "Dobbo, Bob",
             |      "familyName" : "Dobbo",
@@ -27,7 +29,6 @@ class ConvertRequestSpec extends Specification {
             |  "data" : [ "http://foo.com/bar", "http://bar.com/foo" ],
             |  "test" : false
             |}""".stripMargin
-        )
       }
     }
   }
@@ -40,10 +41,12 @@ class ConvertRequestSpec extends Specification {
       val json = ConvertRequest.convertRequestWrites.writes(convertRequest)
       "Then it should default to true" >>{
         val result = Json.prettyPrint(json)
-        result must be equalTo(
+        result must be equalTo
           """{
             |  "dc" : {
-            |    "titles" : [ "My title" ],
+            |    "titles" : [ {
+            |      "title" : "My title"
+            |    } ],
             |    "creators" : [ {
             |      "creatorName" : "Dobbo, Bob",
             |      "familyName" : "Dobbo",
@@ -55,7 +58,6 @@ class ConvertRequestSpec extends Specification {
             |  "data" : [ "http://foo.com/bar" ],
             |  "test" : true
             |}""".stripMargin
-          )
       }
     }
   }

--- a/src/test/scala/org/materialsdatafacility/connect/models/DataCiteSpec.scala
+++ b/src/test/scala/org/materialsdatafacility/connect/models/DataCiteSpec.scala
@@ -1,0 +1,113 @@
+package org.materialsdatafacility.connect.models
+
+import org.joda.time.DateTime
+import org.specs2.mutable._
+import play.api.libs.json._
+
+class DataCiteSpec extends Specification{
+  "Given a DataCite with just a title and an author" >> {
+    "When I generate json" >> {
+      "Then it should match the schema" >> {
+        val dc = new DataCite(Seq("My title", "My second title"), Seq("Bob Dobbo", "Barny Rubble"), None, None, None, None, None, None, None)
+
+        val foo = DataCite.dataCiteWrites.writes(dc)
+        val bar = Json.prettyPrint(foo)
+        val currentYear = new DateTime().year().get
+
+        bar must be equalTo(
+          s"""{
+            |  "titles" : [ "My title", "My second title" ],
+            |  "creators" : [ {
+            |    "creatorName" : "Dobbo, Bob",
+            |    "familyName" : "Dobbo",
+            |    "givenName" : "Bob"
+            |  }, {
+            |    "creatorName" : "Rubble, Barny",
+            |    "familyName" : "Rubble",
+            |    "givenName" : "Barny"
+            |  } ],
+            |  "publisher" : "Materials Data Facility",
+            |  "publicationYear" : "$currentYear"
+            |}""".stripMargin)
+      }
+    }
+  }
+
+  "Given an author formatted as 'last, first">>{
+    val author = "Dobbo, Bob"
+    "When I generate JSON" >> {
+      val json = generateJsonForCreator(author)
+      "Then I should see creator name, family name, and given name extracted correctly">>{
+        (json\"creatorName").as[String] must be equalTo("Dobbo, Bob")
+        (json\"givenName").as[String] must be equalTo("Bob")
+        (json\"familyName").as[String] must be equalTo("Dobbo")
+      }
+    }
+  }
+
+  "Given an author formatted as 'last; first">>{
+    val author = "Dobbo; Bob"
+    "When I generate JSON" >> {
+      val json = generateJsonForCreator(author)
+      "Then I should see creator name, family name, and given name extracted correctly">>{
+        (json\"creatorName").as[String] must be equalTo("Dobbo, Bob")
+        (json\"givenName").as[String] must be equalTo("Bob")
+        (json\"familyName").as[String] must be equalTo("Dobbo")
+      }
+    }
+  }
+
+  "Given an author formatted as a single name">>{
+    val author = "Prince"
+    "When I generate JSON" >> {
+      val json = generateJsonForCreator(author)
+      "Then I should see creator name, family name, and given name extracted correctly">>{
+        (json\"creatorName").as[String] must be equalTo("Prince")
+        (json\"givenName").as[String] must be equalTo("Prince")
+        (json\"familyName").as[String] must be equalTo("")
+      }
+    }
+  }
+
+
+  "Given an author formatted as 'first last">>{
+    val author = "Bob Dobbo"
+    "When I generate JSON" >> {
+      val json = generateJsonForCreator(author)
+      "Then I should see creator name, family name, and given name extracted correctly">>{
+        (json\"creatorName").as[String] must be equalTo("Dobbo, Bob")
+        (json\"givenName").as[String] must be equalTo("Bob")
+        (json\"familyName").as[String] must be equalTo("Dobbo")
+      }
+    }
+  }
+
+
+  "Given the publisher is provided">>{
+    val publisher = "Hearst Publishing"
+    "When I generate JSON" >> {
+      val json = DataCite.dataCiteWrites.writes(new DataCite(Seq("My title"),
+        Seq("Me too"), None, Some(publisher), None, None, None, None, None))
+      "Then I should my publisher extracted correctly">>{
+        (json\"publisher").as[String] must be equalTo(publisher)
+      }
+    }
+  }
+
+  "Given the publication year is provided">>{
+    "When I generate JSON" >> {
+      val json = DataCite.dataCiteWrites.writes(new DataCite(Seq("My title"),
+        Seq("Me too"), None, None, Some(1776), None, None, None, None))
+      "Then I should my publisher extracted correctly">>{
+        (json\"publicationYear").as[String] must be equalTo("1776")
+      }
+    }
+  }
+
+  private def generateJsonForCreator(aCreator: String):JsValue = {
+    (DataCite.dataCiteWrites.writes(new DataCite(Seq("My title"),
+      Seq(aCreator), None, None, None, None, None, None, None)
+    )\"creators")(0)
+  }
+
+}

--- a/src/test/scala/org/materialsdatafacility/connect/models/DataCiteSpec.scala
+++ b/src/test/scala/org/materialsdatafacility/connect/models/DataCiteSpec.scala
@@ -14,9 +14,13 @@ class DataCiteSpec extends Specification{
         val bar = Json.prettyPrint(foo)
         val currentYear = new DateTime().year().get
 
-        bar must be equalTo(
+        bar must be equalTo
           s"""{
-            |  "titles" : [ "My title", "My second title" ],
+            |  "titles" : [ {
+            |    "title" : "My title"
+            |  }, {
+            |    "title" : "My second title"
+            |  } ],
             |  "creators" : [ {
             |    "creatorName" : "Dobbo, Bob",
             |    "familyName" : "Dobbo",
@@ -28,7 +32,7 @@ class DataCiteSpec extends Specification{
             |  } ],
             |  "publisher" : "Materials Data Facility",
             |  "publicationYear" : "$currentYear"
-            |}""".stripMargin)
+            |}""".stripMargin
       }
     }
   }
@@ -100,6 +104,115 @@ class DataCiteSpec extends Specification{
         Seq("Me too"), None, None, Some(1776), None, None, None, None))
       "Then I should my publisher extracted correctly">>{
         (json\"publicationYear").as[String] must be equalTo("1776")
+      }
+    }
+  }
+
+  "Given the desscription is provided">> {
+    "When I generate JSON" >> {
+      val json = DataCite.dataCiteWrites.writes(new DataCite(Seq("My title"),
+        Seq("Me too"), None, None, Some(1776), None, Some("My description"), None, None))
+      "Then I should see the description property encoded" >> {
+        Json.prettyPrint(json) must be equalTo
+          """{
+            |  "titles" : [ {
+            |    "title" : "My title"
+            |  } ],
+            |  "creators" : [ {
+            |    "creatorName" : "too, Me",
+            |    "familyName" : "too",
+            |    "givenName" : "Me"
+            |  } ],
+            |  "publisher" : "Materials Data Facility",
+            |  "publicationYear" : "1776",
+            |  "descriptions" : [ {
+            |    "description" : "My description",
+            |    "descriptionType" : "Other"
+            |  } ]
+            |}""".stripMargin
+      }
+    }
+  }
+
+  "Given the resource type is provided">> {
+    "When I generate JSON" >> {
+      val json = DataCite.dataCiteWrites.writes(new DataCite(Seq("My title"),
+        Seq("Me too"), None, None, Some(1776), Some("Resource type"), None, None, None))
+      "Then I should see the description property encoded" >> {
+        Json.prettyPrint(json) must be equalTo
+          """{
+            |  "titles" : [ {
+            |    "title" : "My title"
+            |  } ],
+            |  "creators" : [ {
+            |    "creatorName" : "too, Me",
+            |    "familyName" : "too",
+            |    "givenName" : "Me"
+            |  } ],
+            |  "publisher" : "Materials Data Facility",
+            |  "publicationYear" : "1776",
+            |  "resourceType" : {
+            |    "resourceType" : "Resource type",
+            |    "resourceTypeGeneral" : "Dataset"
+            |  }
+            |}""".stripMargin
+      }
+    }
+  }
+
+  "Given the DOI is provided">> {
+    "When I generate JSON" >> {
+      val json = DataCite.dataCiteWrites.writes(new DataCite(Seq("My title"),
+        Seq("Me too"), None, None, Some(1776), None, None, Some("123-456"), None))
+      "Then I should see the description property encoded" >> {
+        Json.prettyPrint(json) must be equalTo
+          """{
+            |  "titles" : [ {
+            |    "title" : "My title"
+            |  } ],
+            |  "creators" : [ {
+            |    "creatorName" : "too, Me",
+            |    "familyName" : "too",
+            |    "givenName" : "Me"
+            |  } ],
+            |  "publisher" : "Materials Data Facility",
+            |  "publicationYear" : "1776",
+            |  "identifier" : {
+            |    "identifier" : "123-456",
+            |    "identifierType" : "DOI"
+            |  }
+            |}""".stripMargin
+      }
+    }
+  }
+
+  "Given related DOIs are provided">> {
+    "When I generate JSON" >> {
+      val json = DataCite.dataCiteWrites.writes(new DataCite(Seq("My title"),
+        Seq("Me too"), None, None, Some(1776), None, None, None, Some(Seq("123","456"))))
+      "Then I should see the description property encoded" >> {
+        Json.prettyPrint(json) must be equalTo
+          """{
+            |  "titles" : [ {
+            |    "title" : "My title"
+            |  } ],
+            |  "creators" : [ {
+            |    "creatorName" : "too, Me",
+            |    "familyName" : "too",
+            |    "givenName" : "Me"
+            |  } ],
+            |  "publisher" : "Materials Data Facility",
+            |  "publicationYear" : "1776",
+            |  "relatedIdentifiers" : [ {
+            |    "relatedIdentifier" : "123",
+            |    "relatedIdentifierType" : "DOI",
+            |    "relationType" : "IsPartOf"
+            |  }, {
+            |    "relatedIdentifier" : "456",
+            |    "relatedIdentifierType" : "DOI",
+            |    "relationType" : "IsPartOf"
+            |  } ]
+            |}""".stripMargin
       }
     }
   }

--- a/src/test/scala/org/materialsdatafacility/connect/services/MDFPublishServiceSpec.scala
+++ b/src/test/scala/org/materialsdatafacility/connect/services/MDFPublishServiceSpec.scala
@@ -1,0 +1,77 @@
+package org.materialsdatafacility.connect.services
+
+import com.ning.http.client.Realm.AuthScheme
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import play.api.http.{ContentTypeOf, Writeable}
+import play.api.libs.ws.{Response, WS}
+import play.api.libs.ws.WS.WSRequestHolder
+import play.api.http.Status
+
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class MDFPublishServiceSpec extends Specification with Mockito {
+  val clientId = "123-456-7890"
+  val secret = "shh"
+
+  "Given an MDF Publish Service" >> {
+    "When I attempt to authenticate with a valid client and secret" >> {
+      "then I should receive a success response" >> {
+        val ws = generateAuthMocks(Status.OK)
+
+        val mdfConnect = new MDFPublishService(ws, clientId, secret)
+        val resultFuture = mdfConnect.authenticate()
+
+        val result = Await.result(resultFuture, 10 seconds)
+        result must beASuccessfulTry[String]
+      }
+    }
+
+    "When I attempt to authenticate with a invalid  secret" >> {
+      "then I should receive a failure response" >> {
+        val ws = generateAuthMocks(Status.FORBIDDEN)
+
+        val mdfConnect = new MDFPublishService(ws, clientId, secret)
+        val resultFuture = mdfConnect.authenticate()
+
+        val result = Await.result(resultFuture, 10 seconds)
+        result must beAFailedTry[String]
+      }
+    }
+  }
+
+  "Given an MDF Publish service with an invalid URL" >> {
+    "When I attempt to authenticate" >> {
+      "Then it should fail" >> {
+        val ws = mock[WS.type]
+        val wsWithURL = mock[WSRequestHolder]
+        val wsWithAuth = mock[WSRequestHolder]
+
+        {
+          wsWithURL.withAuth(clientId, secret, AuthScheme.BASIC).returns(wsWithAuth)
+          ws.url("https://BADURL").returns(wsWithURL)
+          wsWithAuth.post(anyMap)(anyObject[Writeable[Map[_, Any]]], anyObject[ContentTypeOf[Map[_, Any]]]).returns(Future.failed(new Exception("bad url")))
+          val mdfConnect = new MDFPublishService(ws, clientId, secret)
+          val resultFuture = mdfConnect.authenticate()
+        } must throwA[Exception]
+      }
+    }
+  }
+
+  def generateAuthMocks(resultStatus: Int): WS.type = {
+    val ws = mock[WS.type]
+    val wsWithURL = mock[WSRequestHolder]
+    val wsWithAuth = mock[WSRequestHolder]
+    val response = mock[Response]
+
+
+    wsWithURL.withAuth(clientId, secret, AuthScheme.BASIC).returns(wsWithAuth)
+    ws.url("https://auth.globus.org/v2/oauth2/token").returns(wsWithURL)
+    wsWithAuth.post(anyMap)(anyObject[Writeable[Map[_, Any]]], anyObject[ContentTypeOf[Map[_, Any]]]).returns(Future(response))
+    response.status.returns(resultStatus)
+    ws
+  }
+
+}

--- a/src/test/scala/org/materialsdatafacility/connect/services/MDFPublishServiceSpec.scala
+++ b/src/test/scala/org/materialsdatafacility/connect/services/MDFPublishServiceSpec.scala
@@ -1,12 +1,14 @@
 package org.materialsdatafacility.connect.services
 
 import com.ning.http.client.Realm.AuthScheme
+import org.materialsdatafacility.connect.models.AccessToken
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import play.api.http.{ContentTypeOf, Writeable}
 import play.api.libs.ws.{Response, WS}
 import play.api.libs.ws.WS.WSRequestHolder
 import play.api.http.Status
+import play.api.libs.json.{JsValue, Json}
 
 import scala.concurrent._
 import scala.concurrent.duration._
@@ -16,28 +18,83 @@ class MDFPublishServiceSpec extends Specification with Mockito {
   val clientId = "123-456-7890"
   val secret = "shh"
 
+  val validJsonResult = Json.parse(
+    """
+      |{
+      |  "access_token" : "Agk1o4vY6e43PwMdd2bB5ep1V8DWVWwkwedGoPga13pqmwj2eeUOCpMe67O938pJ0336MBJ8NPjwm7ujaMEMGIX5ad",
+      |  "expires_in" : 172800,
+      |  "resource_server" : "publish.api.globus.org",
+      |  "token_type" : "Bearer",
+      |  "other_tokens" : [ {
+      |    "access_token" : "AgMg5dvMbdmx0kKYVwbq19bYMjWYkjBv2g6ap31XMzWygOokgEHOCmxdrPmlVXgEKBX63GN98D4YXkFvwPDPYFrXgm",
+      |    "scope" : "urn:globus:auth:scope:data.materialsdatafacility.org:all",
+      |    "expires_in" : 172800,
+      |    "resource_server" : "data.materialsdatafacility.org",
+      |    "token_type" : "Bearer"
+      |  }, {
+      |    "access_token" : "AgmlPWw6PyWl7o34qYnNjbzXw5eW3NP0arp55b07ok7x5O86QJh8CBEdwJBqOXMlJjXWX1azw1Ea3mu8zbQbGtMByM",
+      |    "scope" : "https://auth.globus.org/scopes/c17f27bb-f200-486a-b785-2a25e82af505/connect",
+      |    "expires_in" : 172800,
+      |    "resource_server" : "mdf_dataset_submission",
+      |    "token_type" : "Bearer"
+      |  } ],
+      |  "scope" : "https://auth.globus.org/scopes/ab24b500-37a2-4bad-ab66-d8232c18e6e5/publish_api"
+      |}
+    """.stripMargin)
+
   "Given an MDF Publish Service" >> {
     "When I attempt to authenticate with a valid client and secret" >> {
       "then I should receive a success response" >> {
-        val ws = generateAuthMocks(Status.OK)
+        val ws = generateAuthMocks(Status.OK, validJsonResult)
 
         val mdfConnect = new MDFPublishService(ws, clientId, secret)
         val resultFuture = mdfConnect.authenticate()
 
         val result = Await.result(resultFuture, 10 seconds)
-        result must beASuccessfulTry[String]
+        result must beASuccessfulTry[AccessToken]
       }
     }
 
-    "When I attempt to authenticate with a invalid  secret" >> {
+    "Given an MDF Publish Service" >> {
+      "When I attempt to authenticate with a valid client and secret but no valid access token is available" >> {
+        "then I should receive a success response" >> {
+          val invalidJsonResult = Json.parse(
+            """
+              |{
+              |  "access_token" : "Agk1o4vY6e43PwMdd2bB5ep1V8DWVWwkwedGoPga13pqmwj2eeUOCpMe67O938pJ0336MBJ8NPjwm7ujaMEMGIX5ad",
+              |  "expires_in" : 172800,
+              |  "resource_server" : "publish.api.globus.org",
+              |  "token_type" : "Bearer",
+              |  "other_tokens" : [ {
+              |    "access_token" : "AgMg5dvMbdmx0kKYVwbq19bYMjWYkjBv2g6ap31XMzWygOokgEHOCmxdrPmlVXgEKBX63GN98D4YXkFvwPDPYFrXgm",
+              |    "scope" : "urn:globus:auth:scope:data.materialsdatafacility.org:all",
+              |    "expires_in" : 172800,
+              |    "resource_server" : "data.materialsdatafacility.org",
+              |    "token_type" : "Bearer"
+              |  } ],
+              |  "scope" : "https://auth.globus.org/scopes/ab24b500-37a2-4bad-ab66-d8232c18e6e5/publish_api"
+              |}
+            """.stripMargin)
+          val ws = generateAuthMocks(Status.OK, invalidJsonResult)
+
+          val mdfConnect = new MDFPublishService(ws, clientId, secret)
+          val resultFuture = mdfConnect.authenticate()
+
+          val result = Await.result(resultFuture, 10 seconds)
+          result must beAFailedTry[AccessToken]
+        }
+      }
+    }
+
+      "When I attempt to authenticate with a invalid  secret" >> {
       "then I should receive a failure response" >> {
-        val ws = generateAuthMocks(Status.FORBIDDEN)
+        val ws = generateAuthMocks(Status.FORBIDDEN, validJsonResult)
 
         val mdfConnect = new MDFPublishService(ws, clientId, secret)
         val resultFuture = mdfConnect.authenticate()
 
         val result = Await.result(resultFuture, 10 seconds)
-        result must beAFailedTry[String]
+        result must beAFailedTry[AccessToken]
       }
     }
   }
@@ -60,7 +117,7 @@ class MDFPublishServiceSpec extends Specification with Mockito {
     }
   }
 
-  def generateAuthMocks(resultStatus: Int): WS.type = {
+  def generateAuthMocks(resultStatus: Int, resultJson: JsValue): WS.type = {
     val ws = mock[WS.type]
     val wsWithURL = mock[WSRequestHolder]
     val wsWithAuth = mock[WSRequestHolder]
@@ -71,6 +128,7 @@ class MDFPublishServiceSpec extends Specification with Mockito {
     ws.url("https://auth.globus.org/v2/oauth2/token").returns(wsWithURL)
     wsWithAuth.post(anyMap)(anyObject[Writeable[Map[_, Any]]], anyObject[ContentTypeOf[Map[_, Any]]]).returns(Future(response))
     response.status.returns(resultStatus)
+    response.json returns resultJson
     ws
   }
 


### PR DESCRIPTION
# Problem 
As a Scala developer I want to be able to submit requests to MDF Connect without needing to code the raw REST calls.

# Approach
This library defines Scala bindings for the service. It includes Case Classes for Data Citations, as well as the enclosing Conversion Request message. It also has support for authenticating with Globus Auth and retrieving the token for the MDF Connect service.

# How to test
In order to test the library out you will need [SBT](https://www.scala-sbt.org) and [Scala 2.10](https://www.scala-lang.org/download/) installed.

Check out this branch. 

You can run the unit tests as
```bash
% set clean coverage test coverageReport
```

All of the tests will run and you can verify 96% of the code is covered by unit tests by examining the coverage report at `target/scala-2.10/scoverage-report/index.html`

The snapshot version of this library is available at 
[https://oss.sonatype.org/service/local/repositories/snapshots/content/org/materialsdatafacility/mdfconnect/mdfconnectscala_2.10/0.1-SNAPSHOT](https://oss.sonatype.org/service/local/repositories/snapshots/content/org/materialsdatafacility/mdfconnect/mdfconnectscala_2.10/0.1-SNAPSHOT)